### PR TITLE
add Lightweight History Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@
 
 - [arpl](https://github.com/sisou/arpl) ([Source](https://github.com/sisou/arpl)) ([@sisou](https://github.com/sisou)): CLI tool for remote management of Nimiq nodes
 - [Postgres Chain Mirror](https://github.com/sisou/bun-drizzle-chain-mirror) ([Source](https://github.com/sisou/bun-drizzle-chain-mirror)) ([@sisou](https://github.com/sisou)): Mirrors Nimiq blockchain data into a PostgreSQL database
+- [Lightweight History Node](https://github.com/Albermonte/core-rs-albatross-slim) ([Source](https://github.com/Albermonte/core-rs-albatross-slim)) ([@Albermonte](https://github.com/Albermonte)): Stripped-down read-only history node exposing 11 RPC methods for querying accounts, transactions, and blocks
 
 ### Infrastructure
 

--- a/src/data/dist/nimiq-resources.json
+++ b/src/data/dist/nimiq-resources.json
@@ -254,5 +254,13 @@
     "source": "https://github.com/onmax/nimiq-changelog",
     "description": "Track latest releases and changes across Nimiq ecosystem projects",
     "author": "@onmax"
+  },
+  {
+    "type": "node",
+    "name": "Lightweight History Node",
+    "link": "https://github.com/Albermonte/core-rs-albatross-slim",
+    "source": "https://github.com/Albermonte/core-rs-albatross-slim",
+    "description": "Stripped-down read-only history node exposing 11 RPC methods for querying accounts, transactions, and blocks",
+    "author": "@Albermonte"
   }
 ]

--- a/src/data/nimiq-resources.json
+++ b/src/data/nimiq-resources.json
@@ -254,5 +254,13 @@
     "source": "https://github.com/onmax/nimiq-changelog",
     "description": "Track latest releases and changes across Nimiq ecosystem projects",
     "author": "@onmax"
+  },
+  {
+    "type": "node",
+    "name": "Lightweight History Node",
+    "link": "https://github.com/Albermonte/core-rs-albatross-slim",
+    "source": "https://github.com/Albermonte/core-rs-albatross-slim",
+    "description": "Stripped-down read-only history node exposing 11 RPC methods for querying accounts, transactions, and blocks",
+    "author": "@Albermonte"
   }
 ]

--- a/src/resources.md
+++ b/src/resources.md
@@ -54,6 +54,7 @@
 
 - [arpl](https://github.com/sisou/arpl) ([Source](https://github.com/sisou/arpl)) ([@sisou](https://github.com/sisou)): CLI tool for remote management of Nimiq nodes
 - [Postgres Chain Mirror](https://github.com/sisou/bun-drizzle-chain-mirror) ([Source](https://github.com/sisou/bun-drizzle-chain-mirror)) ([@sisou](https://github.com/sisou)): Mirrors Nimiq blockchain data into a PostgreSQL database
+- [Lightweight History Node](https://github.com/Albermonte/core-rs-albatross-slim) ([Source](https://github.com/Albermonte/core-rs-albatross-slim)) ([@Albermonte](https://github.com/Albermonte)): Stripped-down read-only history node exposing 11 RPC methods for querying accounts, transactions, and blocks
 
 ### Infrastructure
 


### PR DESCRIPTION
Stripped-down read-only history node by @Albermonte. Exposes 11 RPC methods for querying accounts, transactions, and blocks.

https://github.com/Albermonte/core-rs-albatross-slim